### PR TITLE
fix(mpi_run): subprocess.call FileNotFoundError

### DIFF
--- a/mpi_run.py
+++ b/mpi_run.py
@@ -16,7 +16,7 @@ def main():
     cmd = 'mpiexec -n {:d} python DeepMimic_Optimizer.py '.format(num_workers)
     cmd += ' '.join(args)
     Logger.print('cmd: ' + cmd)
-    subprocess.call(cmd)
+    subprocess.call(cmd, shell=True)
     return
 
 if __name__ == '__main__':


### PR DESCRIPTION
`subprocess.call` doesn't use a shell to run `mpiexec`

```
FileNotFoundError: [Errno 2] No such file or directory: 'mpiexec -n 8 python3 DeepMimic_Optimizer.py --arg_file args/train_humanoid3d_walk_args.txt --num_workers 8': 'mpiexec -n 8 python3 DeepMimic_Optimizer.py --arg_file args/train_humanoid3d_walk_args.txt --num_workers 8'
```
- os: `Linux server 4.15.0-36-generic #39-Ubuntu SMP Mon Sep 24 16:19:09 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux`
- Python: `Python 3.6.5`