### PR TITLE
Add override where possible

### DIFF
--- a/DeepMimicCore/sim/Ground.h
+++ b/DeepMimicCore/sim/Ground.h
@@ -69,7 +69,7 @@ public:
 	virtual size_t GetUpdateCount() const;
 	virtual void SeedRand(unsigned long seed);
 	virtual void SamplePlacement(const tVector& origin, tVector& out_pos, tQuaternion& out_rot);
-	virtual tVector GetSize() const;
+	virtual tVector GetSize() const override;
 	virtual double GetVertSpacingX() const;
 	virtual double GetVertSpacingZ() const;
 

--- a/DeepMimicCore/sim/SimBodyLink.h
+++ b/DeepMimicCore/sim/SimBodyLink.h
@@ -21,22 +21,22 @@ public:
 	virtual void Init(const std::shared_ptr<cWorld>& world, const std::shared_ptr<cMultiBody>& mult_body, const tParams& params);
 	virtual tVector GetSize() const override;
 	
-	virtual tVector GetLinearVelocity() const;
-	virtual tVector GetLinearVelocity(const tVector& local_pos) const;
-	virtual void SetLinearVelocity(const tVector& vel);
-	virtual tVector GetAngularVelocity() const;
-	virtual void SetAngularVelocity(const tVector& vel);
+	virtual tVector GetLinearVelocity() const override;
+	virtual tVector GetLinearVelocity(const tVector& local_pos) const override;
+	virtual void SetLinearVelocity(const tVector& vel) override;
+	virtual tVector GetAngularVelocity() const override;
+	virtual void SetAngularVelocity(const tVector& vel) override;
 
 	virtual double GetMass() const;
 	virtual double GetFriction() const;
 	virtual void SetFriction(double friction);
 
-	virtual void ApplyForce(const tVector& force);
-	virtual void ApplyForce(const tVector& force, const tVector& local_pos);
-	virtual void ApplyTorque(const tVector& torque);
-	virtual void ClearForces();
+	virtual void ApplyForce(const tVector& force) override;
+	virtual void ApplyForce(const tVector& force, const tVector& local_pos) override;
+	virtual void ApplyTorque(const tVector& torque) override;
+	virtual void ClearForces() override;
 
-	virtual cShape::eShape GetShape() const;
+	virtual cShape::eShape GetShape() const override;
 	virtual void UpdateVel(const tVector& lin_vel, const tVector& ang_vel);
 	virtual const std::shared_ptr<cMultiBody>& GetMultBody() const;
 	virtual int GetJointID() const;
@@ -58,6 +58,6 @@ protected:
 
 	virtual void RemoveFromWorld();
 
-	virtual const btCollisionObject* GetCollisionObject() const;
-	virtual btCollisionObject* GetCollisionObject();
+	virtual const btCollisionObject* GetCollisionObject() const override;
+	virtual btCollisionObject* GetCollisionObject() override;
 };

--- a/DeepMimicCore/sim/SimBodyLink.h
+++ b/DeepMimicCore/sim/SimBodyLink.h
@@ -19,7 +19,7 @@ public:
 	virtual ~cSimBodyLink();
 
 	virtual void Init(const std::shared_ptr<cWorld>& world, const std::shared_ptr<cMultiBody>& mult_body, const tParams& params);
-	virtual tVector GetSize() const;
+	virtual tVector GetSize() const override;
 	
 	virtual tVector GetLinearVelocity() const;
 	virtual tVector GetLinearVelocity(const tVector& local_pos) const;

--- a/DeepMimicCore/sim/SimBox.h
+++ b/DeepMimicCore/sim/SimBox.h
@@ -27,7 +27,7 @@ public:
 	virtual void Init(const std::shared_ptr<cWorld>& world, const tParams& params);
 	virtual tVector GetSize() const;
 
-	virtual cShape::eShape GetShape() const;
+	virtual cShape::eShape GetShape() const override;
 
 protected:
 };

--- a/DeepMimicCore/sim/SimBox.h
+++ b/DeepMimicCore/sim/SimBox.h
@@ -25,7 +25,7 @@ public:
 	virtual ~cSimBox();
 
 	virtual void Init(const std::shared_ptr<cWorld>& world, const tParams& params);
-	virtual tVector GetSize() const;
+	virtual tVector GetSize() const override;
 
 	virtual cShape::eShape GetShape() const override;
 

--- a/DeepMimicCore/sim/SimCapsule.h
+++ b/DeepMimicCore/sim/SimCapsule.h
@@ -29,7 +29,7 @@ public:
 	virtual double GetHeight() const;
 	virtual double GetRadius() const;
 
-	virtual cShape::eShape GetShape() const;
+	virtual cShape::eShape GetShape() const override;
 	virtual tVector GetSize() const;
 
 protected:

--- a/DeepMimicCore/sim/SimCapsule.h
+++ b/DeepMimicCore/sim/SimCapsule.h
@@ -30,7 +30,7 @@ public:
 	virtual double GetRadius() const;
 
 	virtual cShape::eShape GetShape() const override;
-	virtual tVector GetSize() const;
+	virtual tVector GetSize() const override;
 
 protected:
 };

--- a/DeepMimicCore/sim/SimCharacter.h
+++ b/DeepMimicCore/sim/SimCharacter.h
@@ -69,7 +69,7 @@ public:
 	virtual tVector CalcCOM() const;
 	virtual tVector CalcCOMVel() const;
 	virtual void CalcAABB(tVector& out_min, tVector& out_max) const;
-	virtual tVector GetSize() const;
+	virtual tVector GetSize() const override;
 
 	virtual const cSimBodyJoint& GetJoint(int joint_id) const;
 	virtual cSimBodyJoint& GetJoint(int joint_id);

--- a/DeepMimicCore/sim/SimCharacter.h
+++ b/DeepMimicCore/sim/SimCharacter.h
@@ -34,41 +34,41 @@ public:
 	virtual ~cSimCharacter();
 
 	virtual bool Init(const std::shared_ptr<cWorld>& world, const tParams& params);
-	virtual void Clear();
-	virtual void Reset();
-	virtual void Update(double time_step);
+	virtual void Clear() override;
+	virtual void Reset() override;
+	virtual void Update(double time_step) override;
 	virtual void PostUpdate(double time_step);
 
-	virtual tVector GetRootPos() const;
-	virtual void GetRootRotation(tVector& out_axis, double& out_theta) const;
-	virtual tQuaternion GetRootRotation() const;
+	virtual tVector GetRootPos() const override;
+	virtual void GetRootRotation(tVector& out_axis, double& out_theta) const override;
+	virtual tQuaternion GetRootRotation() const override;
 	virtual tVector GetRootVel() const;
 	virtual tVector GetRootAngVel() const;
 	virtual const Eigen::MatrixXd& GetBodyDefs() const;
-	virtual void SetRootPos(const tVector& pos);
+	virtual void SetRootPos(const tVector& pos) override;
 	virtual void SetRootRotation(const tVector& axis, double theta);
-	virtual void SetRootRotation(const tQuaternion& q);
+	virtual void SetRootRotation(const tQuaternion& q) override;
 	virtual void SetRootTransform(const tVector& pos, const tQuaternion& rot);
 
-	virtual void SetRootVel(const tVector& vel);
-	virtual void SetRootAngVel(const tVector& ang_vel);
+	virtual void SetRootVel(const tVector& vel) override;
+	virtual void SetRootAngVel(const tVector& ang_vel) override;
 	
-	virtual tQuaternion CalcHeadingRot() const;
+	virtual tQuaternion CalcHeadingRot() const override;
 
 	virtual int GetNumBodyParts() const;
 
-	virtual void SetPose(const Eigen::VectorXd& pose);
-	virtual void SetVel(const Eigen::VectorXd& vel);
+	virtual void SetPose(const Eigen::VectorXd& pose) override;
+	virtual void SetVel(const Eigen::VectorXd& vel) override;
 
-	virtual tVector CalcJointPos(int joint_id) const;
-	virtual tVector CalcJointVel(int joint_id) const;
-	virtual void CalcJointWorldRotation(int joint_id, tVector& out_axis, double& out_theta) const;
-	virtual tQuaternion CalcJointWorldRotation(int joint_id) const;
-	virtual tMatrix BuildJointWorldTrans(int joint_id) const;
+	virtual tVector CalcJointPos(int joint_id) const override;
+	virtual tVector CalcJointVel(int joint_id) const override;
+	virtual void CalcJointWorldRotation(int joint_id, tVector& out_axis, double& out_theta) const override;
+	virtual tQuaternion CalcJointWorldRotation(int joint_id) const override;
+	virtual tMatrix BuildJointWorldTrans(int joint_id) const override;
 
-	virtual tVector CalcCOM() const;
-	virtual tVector CalcCOMVel() const;
-	virtual void CalcAABB(tVector& out_min, tVector& out_max) const;
+	virtual tVector CalcCOM() const override;
+	virtual tVector CalcCOMVel() const override;
+	virtual void CalcAABB(tVector& out_min, tVector& out_max) const override;
 	virtual tVector GetSize() const override;
 
 	virtual const cSimBodyJoint& GetJoint(int joint_id) const;
@@ -81,12 +81,12 @@ public:
 	virtual std::shared_ptr<cSimBodyLink> GetRootPart();
 
 	virtual void RegisterContacts(int contact_flags, int filter_flags);
-	virtual void UpdateContact(int contact_flags, int filter_flags);
-	virtual bool IsInContact() const;
+	virtual void UpdateContact(int contact_flags, int filter_flags) override;
+	virtual bool IsInContact() const override;
 	virtual bool IsInContact(int idx) const;
 	virtual const tEigenArr<cContactManager::tContactPt>& GetContactPts(int idx) const;
-	virtual const tEigenArr<cContactManager::tContactPt>& GetContactPts() const;
-	virtual const cContactManager::tContactHandle& GetContactHandle() const;
+	virtual const tEigenArr<cContactManager::tContactPt>& GetContactPts() const override;
+	virtual const cContactManager::tContactHandle& GetContactHandle() const override;
 	
 	virtual bool HasFallen() const;
 	virtual bool HasStumbled() const;
@@ -103,10 +103,10 @@ public:
 	virtual const std::shared_ptr<cCharController>& GetController() const;
 	virtual void EnableController(bool enable);
 
-	virtual void ApplyForce(const tVector& force);
-	virtual void ApplyForce(const tVector& force, const tVector& local_pos);
-	virtual void ApplyTorque(const tVector& torque);
-	virtual void ClearForces();
+	virtual void ApplyForce(const tVector& force) override;
+	virtual void ApplyForce(const tVector& force, const tVector& local_pos) override;
+	virtual void ApplyTorque(const tVector& torque) override;
+	virtual void ClearForces() override;
 	virtual void ApplyControlForces(const Eigen::VectorXd& tau);
 	virtual void PlayPossum();
 
@@ -116,7 +116,7 @@ public:
 	virtual void SetLinearDamping(double damping);
 	virtual void SetAngularDamping(double damping);
 
-	virtual const std::shared_ptr<cWorld>& GetWorld() const;
+	virtual const std::shared_ptr<cWorld>& GetWorld() const override;
 	virtual const std::shared_ptr<cMultiBody>& GetMultiBody() const;
 	virtual const std::vector<std::shared_ptr<btMultiBodyJointLimitConstraint>>& GetConstraints() const;
 
@@ -188,5 +188,5 @@ protected:
 
 	virtual bool CheckFallContact() const;
 	virtual const btCollisionObject* GetCollisionObject() const override;
-	virtual btCollisionObject* GetCollisionObject();
+	virtual btCollisionObject* GetCollisionObject() override;
 };

--- a/DeepMimicCore/sim/SimCharacter.h
+++ b/DeepMimicCore/sim/SimCharacter.h
@@ -121,24 +121,24 @@ public:
 	virtual const std::vector<std::shared_ptr<btMultiBodyJointLimitConstraint>>& GetConstraints() const;
 
 	// cSimObj Interface
-	virtual tVector GetPos() const;
-	virtual void SetPos(const tVector& pos);
-	virtual void GetRotation(tVector& out_axis, double& out_theta) const;
-	virtual tQuaternion GetRotation() const;
-	virtual void SetRotation(const tVector& axis, double theta);
-	virtual void SetRotation(const tQuaternion& q);
-	virtual tMatrix GetWorldTransform() const;
+	virtual tVector GetPos() const override;
+	virtual void SetPos(const tVector& pos) override;
+	virtual void GetRotation(tVector& out_axis, double& out_theta) const override;
+	virtual tQuaternion GetRotation() const override;
+	virtual void SetRotation(const tVector& axis, double theta) override;
+	virtual void SetRotation(const tQuaternion& q) override;
+	virtual tMatrix GetWorldTransform() const override;
 
-	virtual tVector GetLinearVelocity() const;
-	virtual tVector GetLinearVelocity(const tVector& local_pos) const;
-	virtual void SetLinearVelocity(const tVector& vel);
-	virtual tVector GetAngularVelocity() const;
-	virtual void SetAngularVelocity(const tVector& vel);
+	virtual tVector GetLinearVelocity() const override;
+	virtual tVector GetLinearVelocity(const tVector& local_pos) const override;
+	virtual void SetLinearVelocity(const tVector& vel) override;
+	virtual tVector GetAngularVelocity() const override;
+	virtual void SetAngularVelocity(const tVector& vel) override;
 
-	virtual short GetColGroup() const;
-	virtual void SetColGroup(short col_group);
-	virtual short GetColMask() const;
-	virtual void SetColMask(short col_mask);
+	virtual short GetColGroup() const override;
+	virtual void SetColGroup(short col_group) override;
+	virtual short GetColMask() const override;
+	virtual void SetColMask(short col_mask) override;
 
 protected:
 	std::shared_ptr<cMultiBody> mMultBody;
@@ -187,6 +187,6 @@ protected:
 	virtual void BuildVel(Eigen::VectorXd& out_vel) const;
 
 	virtual bool CheckFallContact() const;
-	virtual const btCollisionObject* GetCollisionObject() const;
+	virtual const btCollisionObject* GetCollisionObject() const override;
 	virtual btCollisionObject* GetCollisionObject();
 };

--- a/DeepMimicCore/sim/SimCylinder.h
+++ b/DeepMimicCore/sim/SimCylinder.h
@@ -29,7 +29,7 @@ public:
 	virtual double GetHeight() const;
 	virtual double GetRadius() const;
 
-	virtual cShape::eShape GetShape() const;
+	virtual cShape::eShape GetShape() const override;
 	virtual tVector GetSize() const;
 
 protected:

--- a/DeepMimicCore/sim/SimCylinder.h
+++ b/DeepMimicCore/sim/SimCylinder.h
@@ -30,7 +30,7 @@ public:
 	virtual double GetRadius() const;
 
 	virtual cShape::eShape GetShape() const override;
-	virtual tVector GetSize() const;
+	virtual tVector GetSize() const override;
 
 protected:
 };

--- a/DeepMimicCore/sim/SimPlane.h
+++ b/DeepMimicCore/sim/SimPlane.h
@@ -23,7 +23,7 @@ public:
 	virtual void Init(const std::shared_ptr<cWorld>& world, const tParams& params);
 	virtual tVector GetCoeffs() const;
 	virtual cShape::eShape GetShape() const;
-	virtual tVector GetSize() const;
+	virtual tVector GetSize() const override;
 
 protected:
 };

--- a/DeepMimicCore/sim/SimPlane.h
+++ b/DeepMimicCore/sim/SimPlane.h
@@ -22,7 +22,7 @@ public:
 
 	virtual void Init(const std::shared_ptr<cWorld>& world, const tParams& params);
 	virtual tVector GetCoeffs() const;
-	virtual cShape::eShape GetShape() const;
+	virtual cShape::eShape GetShape() const override;
 	virtual tVector GetSize() const override;
 
 protected:

--- a/DeepMimicCore/sim/SimSphere.h
+++ b/DeepMimicCore/sim/SimSphere.h
@@ -28,7 +28,7 @@ public:
 	virtual double GetRadius() const;
 	virtual tVector GetSize() const override;
 
-	virtual cShape::eShape GetShape() const;
+	virtual cShape::eShape GetShape() const override;
 
 protected:
 };

--- a/DeepMimicCore/sim/SimSphere.h
+++ b/DeepMimicCore/sim/SimSphere.h
@@ -26,7 +26,7 @@ public:
 
 	virtual void Init(const std::shared_ptr<cWorld>& world, const tParams& params);
 	virtual double GetRadius() const;
-	virtual tVector GetSize() const;
+	virtual tVector GetSize() const override;
 
 	virtual cShape::eShape GetShape() const;
 


### PR DESCRIPTION
This PR adds override specifiers everywhere that they should be.

clang++ found these for me by specifying -Winconsistent-missing-override